### PR TITLE
Make a bunch of functions const

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gap-buf"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["FrozenLib", "AhoyISki"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gap-buf"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["FrozenLib", "AhoyISki"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -20,7 +20,6 @@ test-strategy = "0.2.0"
 proptest = "1.0.0"
 
 [features]
-default = ["bincode"]
 docs-rs = []
 bincode = ["dep:bincode", "dep:unty"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gap-buf"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["FrozenLib", "AhoyISki"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -11,12 +11,16 @@ categories = ["data-structures"]
 description = "Generic gap buffer."
 edition = "2024"
 
-[features]
-docs-rs = []
+[dependencies]
+bincode = { version = "2.0.1", optional = true }
 
 [dev-dependencies]
 test-strategy = "0.2.0"
 proptest = "1.0.0"
+
+[features]
+docs-rs = []
+bincode = ["dep:bincode"]
 
 [package.metadata.docs.rs]
 features = ["docs-rs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,12 +13,14 @@ edition = "2024"
 
 [dependencies]
 bincode = { version = "2.0.1", optional = true }
+unty = "0.0.5"
 
 [dev-dependencies]
 test-strategy = "0.2.0"
 proptest = "1.0.0"
 
 [features]
+default = ["bincode"]
 docs-rs = []
 bincode = ["dep:bincode"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gap-buf"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["FrozenLib", "AhoyISki"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,6 @@ edition = "2021"
 [features]
 docs-rs = []
 
-[dependencies]
-
 [dev-dependencies]
 test-strategy = "0.2.0"
 proptest = "1.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "gapbuffer"
+name = "gap-buf"
 version = "0.1.0"
 authors = ["FrozenLib", "AhoyISki"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
-repository = "https://github.com/AhoyISki/gapbuffer-rs"
-documentation = "https://docs.rs/gapbuffer/"
+repository = "https://github.com/AhoyISki/gap-buf-rs"
+documentation = "https://docs.rs/gap-buf/"
 keywords = ["gap", "gapbuffer"]
 categories = ["data-structures"]
 description = "Generic gap buffer."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gap-buf"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["FrozenLib", "AhoyISki"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -13,7 +13,7 @@ edition = "2024"
 
 [dependencies]
 bincode = { version = "2.0.1", optional = true }
-unty = "0.0.5"
+unty = { version = "0.0.5", optional = true }
 
 [dev-dependencies]
 test-strategy = "0.2.0"
@@ -22,7 +22,7 @@ proptest = "1.0.0"
 [features]
 default = ["bincode"]
 docs-rs = []
-bincode = ["dep:bincode"]
+bincode = ["dep:bincode", "dep:unty"]
 
 [package.metadata.docs.rs]
 features = ["docs-rs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
-name = "gapbuf"
-version = "0.1.4"
-authors = ["FrozenLib"]
+name = "gapbuffer"
+version = "0.1.0"
+authors = ["FrozenLib", "AhoyISki"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
-repository = "https://github.com/frozenlib/gapbuf-rs"
-documentation = "https://docs.rs/gapbuf/"
+repository = "https://github.com/AhoyISki/gapbuffer-rs"
+documentation = "https://docs.rs/gapbuffer/"
 keywords = ["gap", "gapbuffer"]
 categories = ["data-structures"]
 description = "Generic gap buffer."
-edition = "2021"
+edition = "2024"
 
 [features]
 docs-rs = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gap-buf"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["FrozenLib", "AhoyISki"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gap-buf"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["FrozenLib", "AhoyISki"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# gapbuf-rs
+# gapbuffer-rs
 
-[![Crates.io](https://img.shields.io/crates/v/gapbuf.svg)](https://crates.io/crates/gapbuf)
-[![Docs.rs](https://docs.rs/gapbuf/badge.svg)](https://docs.rs/gapbuf)
-[![Actions Status](https://github.com/frozenlib/gapbuf-rs/workflows/CI/badge.svg)](https://github.com/frozenlib/gapbuf-rs/actions)
+[![Crates.io](https://img.shields.io/crates/v/gapbuffer.svg)](https://crates.io/crates/gapbuf)
+[![Docs.rs](https://docs.rs/gapbuf/badge.svg)](https://docs.rs/gapbuffer)
+[![Actions Status](https://github.com/AhoyISki/gapbuffer-rs/workflows/CI/badge.svg)](https://github.com/AhoyISki/gapbuffer-rs/actions)
 
 Generic gap buffer implementation in Rust.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# gapbuffer-rs
+# gap-buf-rs
 
-[![Crates.io](https://img.shields.io/crates/v/gapbuffer.svg)](https://crates.io/crates/gapbuf)
-[![Docs.rs](https://docs.rs/gapbuf/badge.svg)](https://docs.rs/gapbuffer)
-[![Actions Status](https://github.com/AhoyISki/gapbuffer-rs/workflows/CI/badge.svg)](https://github.com/AhoyISki/gapbuffer-rs/actions)
+[![Crates.io](https://img.shields.io/crates/v/gap-buf.svg)](https://crates.io/crates/gap-buf)
+[![Docs.rs](https://docs.rs/gapbuf/badge.svg)](https://docs.rs/gap-buf)
+[![Actions Status](https://github.com/AhoyISki/gap-buf-rs/workflows/CI/badge.svg)](https://github.com/AhoyISki/gap-buf-rs/actions)
 
 Generic gap buffer implementation in Rust.
 
@@ -12,7 +12,7 @@ This type has methods similar to `Vec`.
 ## Examples
 
 ```rust
-use gapbuf::gap_buffer;
+use gap_buf::gap_buffer;
 
 let mut b = gap_buffer![1, 2, 3];
 b.insert(1, 10);

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -7,4 +7,4 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-gapbuf = { path = "../" }
+gap_buf = { path = "../" }

--- a/benchmarks/benches/benches.rs
+++ b/benchmarks/benches/benches.rs
@@ -3,7 +3,7 @@
 extern crate test;
 
 use self::test::Bencher;
-use gapbuf::GapBuffer;
+use gap_buf::GapBuffer;
 use std::collections::VecDeque;
 
 #[bench]

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,4 +1,4 @@
-use gapbuf::gap_buffer;
+use gap_buf::gap_buffer;
 
 fn main() {
     let mut b = gap_buffer![1, 2, 3];

--- a/src/gap_buffer.rs
+++ b/src/gap_buffer.rs
@@ -59,6 +59,7 @@ macro_rules! gap_buffer {
 ///
 /// `GapBuffer<T>` has methods similar to [`Vec`](std::vec::Vec).
 #[derive(Hash)]
+#[cfg_attr(feature = "bincode", derive(bincode::Decode, bincode::Encode))]
 pub struct GapBuffer<T>(RawGapBuffer<T>);
 
 impl<T> GapBuffer<T> {
@@ -724,6 +725,7 @@ impl<'gb, T: 'gb + Copy> Extend<&'gb T> for GapBuffer<T> {
 }
 
 #[derive(Hash)]
+#[cfg_attr(feature = "bincode", derive(bincode::Decode, bincode::Encode))]
 struct RawGapBuffer<T>(Slice<T>);
 
 impl<T> RawGapBuffer<T> {
@@ -1196,6 +1198,19 @@ impl<T: bincode::Decode<Context>, Context> bincode::Decode<Context> for Slice<T>
         decoder: &mut D,
     ) -> Result<Self, bincode::error::DecodeError> {
         let vec: Vec<T> = bincode::Decode::decode(decoder)?;
+        Ok(Self::from_vec(vec))
+    }
+}
+
+#[cfg(feature = "bincode")]
+impl<'de, T, Context> bincode::BorrowDecode<'de, Context> for Slice<T>
+where
+    T: bincode::BorrowDecode<'de, Context>,
+{
+    fn borrow_decode<D: bincode::de::BorrowDecoder<'de, Context = Context>>(
+        decoder: &mut D,
+    ) -> Result<Self, bincode::error::DecodeError> {
+        let vec: Vec<T> = bincode::BorrowDecode::borrow_decode(decoder)?;
         Ok(Self::from_vec(vec))
     }
 }

--- a/src/gap_buffer.rs
+++ b/src/gap_buffer.rs
@@ -17,7 +17,7 @@ use std::slice;
 /// - Create a [`GapBuffer`] containing a given list of elements:
 ///
 /// ```
-/// use gapbuf::gap_buffer;
+/// use gap_buf::gap_buffer;
 /// let b = gap_buffer![1, 2, 3];
 /// assert_eq!(b.len(), 3);
 /// assert_eq!(b[0], 1);
@@ -28,14 +28,12 @@ use std::slice;
 /// - Create a [`GapBuffer`] from a given element and size:
 ///
 /// ```
-/// use gapbuf::gap_buffer;
+/// use gap_buf::gap_buffer;
 /// let b = gap_buffer!["abc"; 2];
 /// assert_eq!(b.len(), 2);
 /// assert_eq!(b[0], "abc");
 /// assert_eq!(b[1], "abc");
 /// ```
-///
-/// [`GapBuffer`]: ../gapbuf/struct.GapBuffer.html
 #[macro_export]
 macro_rules! gap_buffer {
     ($elem:expr; $n:expr) => (
@@ -70,7 +68,7 @@ impl<T> GapBuffer<T> {
     ///
     /// # Examples
     /// ```
-    /// # use gapbuf::GapBuffer;
+    /// # use gap_buf::GapBuffer;
     /// let mut buf = GapBuffer::<i32>::new();
     ///
     /// assert_eq!(buf.is_empty(), true);
@@ -79,7 +77,7 @@ impl<T> GapBuffer<T> {
     /// ```
     ///
     /// ```
-    /// use gapbuf::GapBuffer;
+    /// use gap_buf::GapBuffer;
     ///
     /// let mut buf = GapBuffer::new();
     /// buf.push_back(5);
@@ -93,7 +91,7 @@ impl<T> GapBuffer<T> {
     ///
     /// # Examples
     /// ```
-    /// use gapbuf::GapBuffer;
+    /// use gap_buf::GapBuffer;
     ///
     /// let buf: GapBuffer<i32> = GapBuffer::with_capacity(5);
     /// assert_eq!(buf.is_empty(), true);
@@ -110,7 +108,7 @@ impl<T> GapBuffer<T> {
     ///
     /// # Examples
     /// ```
-    /// use gapbuf::GapBuffer;
+    /// use gap_buf::GapBuffer;
     ///
     /// let buf: GapBuffer<i32> = GapBuffer::with_capacity(10);
     /// assert_eq!(buf.capacity(), 10);
@@ -130,7 +128,7 @@ impl<T> GapBuffer<T> {
     ///
     /// # Examples
     /// ```
-    /// use gapbuf::GapBuffer;
+    /// use gap_buf::GapBuffer;
     ///
     /// let mut buf = GapBuffer::new();
     /// buf.push_back(1);
@@ -154,7 +152,7 @@ impl<T> GapBuffer<T> {
     ///
     /// # Examples
     /// ```
-    /// use gapbuf::GapBuffer;
+    /// use gap_buf::GapBuffer;
     ///
     /// let mut buf = GapBuffer::new();
     /// buf.push_back(1);
@@ -191,7 +189,7 @@ impl<T> GapBuffer<T> {
     ///
     /// # Examples
     /// ```
-    /// use gapbuf::GapBuffer;
+    /// use gap_buf::GapBuffer;
     ///
     /// let mut buf = GapBuffer::new();
     /// buf.push_back(1);
@@ -350,7 +348,7 @@ impl<T> GapBuffer<T> {
     ///
     /// # Examples
     /// ```
-    /// use gapbuf::gap_buffer;
+    /// use gap_buf::gap_buffer;
     ///
     /// let mut buf = gap_buffer![1, 2, 3, 4, 5];
     /// buf.set_gap(5);
@@ -390,7 +388,7 @@ impl<T> GapBuffer<T> {
     ///
     /// # Examples
     /// ```
-    /// use gapbuf::gap_buffer;
+    /// use gap_buf::gap_buffer;
     ///
     /// let mut buf = gap_buffer![1, 2, 3, 4, 5];
     /// let value = buf.remove(0);
@@ -431,7 +429,7 @@ impl<T> GapBuffer<T> {
     /// # Examples
     ///
     /// ```
-    /// use gapbuf::gap_buffer;
+    /// use gap_buf::gap_buffer;
     ///
     /// let mut buf = gap_buffer![1, 2, 3, 4];
     /// buf.truncate(2);
@@ -458,7 +456,7 @@ impl<T> GapBuffer<T> {
     /// # Examples
     ///
     /// ```
-    /// use gapbuf::gap_buffer;
+    /// use gap_buf::gap_buffer;
     ///
     /// let mut buf = gap_buffer![1, 2, 3, 4];
     /// buf.retain(|&x| x%2 == 0);
@@ -504,7 +502,7 @@ impl<T> GapBuffer<T> {
     /// # Examples
     ///
     /// ```
-    /// use gapbuf::gap_buffer;
+    /// use gap_buf::gap_buffer;
     ///
     /// let mut buf = gap_buffer![1, 2, 3, 4];
     ///
@@ -535,7 +533,7 @@ impl<T> GapBuffer<T> {
     /// # Examples
     ///
     /// ```
-    /// use gapbuf::gap_buffer;
+    /// use gap_buf::gap_buffer;
     ///
     /// let mut buf = gap_buffer![1, 2, 3, 4];
     ///
@@ -572,7 +570,7 @@ impl<T> GapBuffer<T> {
     /// # Examples
     ///
     /// ```
-    /// use gapbuf::gap_buffer;
+    /// use gap_buf::gap_buffer;
     ///
     /// let mut b = gap_buffer![1, 2, 3, 4];
     /// let r : Vec<_> = b.splice(1..3, vec![7, 8, 9]).collect();
@@ -954,7 +952,7 @@ impl<T> Slice<T> {
     ///
     /// # Examples
     /// ```
-    /// use gapbuf::gap_buffer;
+    /// use gap_buf::gap_buffer;
     ///
     /// let buf = gap_buffer![1, 2, 3, 4, 5];
     ///
@@ -978,7 +976,7 @@ impl<T> Slice<T> {
     ///
     /// # Examples
     /// ```
-    /// use gapbuf::gap_buffer;
+    /// use gap_buf::gap_buffer;
     ///
     /// let mut buf = gap_buffer![1, 2, 3, 4, 5];
     /// {
@@ -1052,7 +1050,7 @@ impl<T> Slice<T> {
     ///
     /// # Examples
     /// ```
-    /// use gapbuf::gap_buffer;
+    /// use gap_buf::gap_buffer;
     ///
     /// let mut buf = gap_buffer![1, 2, 3, 4, 5];
     /// buf.set_gap(2);
@@ -1078,7 +1076,7 @@ impl<T> Slice<T> {
     ///
     /// # Examples
     /// ```
-    /// use gapbuf::gap_buffer;
+    /// use gap_buf::gap_buffer;
     ///
     /// let mut buf = gap_buffer![1, 2, 3, 4, 5];
     /// buf.set_gap(2);

--- a/src/gap_buffer.rs
+++ b/src/gap_buffer.rs
@@ -1191,7 +1191,7 @@ unsafe impl<T: Sync> Sync for Slice<T> {}
 unsafe impl<T: Send> Send for Slice<T> {}
 
 #[cfg(feature = "bincode")]
-impl<T: bincode::Decode<Context> + 'static, Context> bincode::Decode<Context> for Slice<T> {
+impl<T: bincode::Decode<Context>, Context> bincode::Decode<Context> for Slice<T> {
     fn decode<D: bincode::de::Decoder<Context = Context>>(
         decoder: &mut D,
     ) -> Result<Self, bincode::error::DecodeError> {
@@ -1201,7 +1201,7 @@ impl<T: bincode::Decode<Context> + 'static, Context> bincode::Decode<Context> fo
 }
 
 #[cfg(feature = "bincode")]
-impl<T: bincode::Encode + 'static> bincode::Encode for Slice<T> {
+impl<T: bincode::Encode> bincode::Encode for Slice<T> {
     fn encode<E: bincode::enc::Encoder>(
         &self,
         encoder: &mut E,

--- a/src/gap_buffer.rs
+++ b/src/gap_buffer.rs
@@ -85,7 +85,7 @@ impl<T> GapBuffer<T> {
     /// buf.push_back(5);
     /// ```
     #[inline]
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         GapBuffer(RawGapBuffer::new())
     }
 
@@ -116,8 +116,8 @@ impl<T> GapBuffer<T> {
     /// assert_eq!(buf.capacity(), 10);
     /// ```
     #[inline]
-    pub fn capacity(&self) -> usize {
-        self.cap
+    pub const fn capacity(&self) -> usize {
+        self.0.0.cap
     }
 
     /// Reserves capacity for at least additional more elements to be inserted in the given `GapBuffer<T>`.
@@ -239,8 +239,8 @@ impl<T> GapBuffer<T> {
 
     /// Return gap offset of the `GapBuffer<T>`.
     #[inline]
-    pub fn gap(&self) -> usize {
-        self.gap
+    pub const fn gap(&self) -> usize {
+        self.0.0.gap
     }
 
     #[inline]
@@ -689,7 +689,7 @@ impl<'a, T: 'a + Copy> Extend<&'a T> for GapBuffer<T> {
 struct RawGapBuffer<T>(Slice<T>);
 
 impl<T> RawGapBuffer<T> {
-    fn new() -> Self {
+    const fn new() -> Self {
         RawGapBuffer(Slice::empty())
     }
 
@@ -718,6 +718,7 @@ impl<T> RawGapBuffer<T> {
         }
         self.0.cap = new_cap;
     }
+    
     fn get_layout(cap: usize) -> Layout {
         let new_size = size_of::<T>()
             .checked_mul(cap)
@@ -754,7 +755,7 @@ pub struct RangeMut<'a, T: 'a> {
 }
 impl<'a, T: 'a> Range<'a, T> {
     #[inline]
-    unsafe fn new(s: Slice<T>) -> Self {
+    const unsafe fn new(s: Slice<T>) -> Self {
         Range {
             s,
             _phantom: PhantomData,
@@ -763,7 +764,7 @@ impl<'a, T: 'a> Range<'a, T> {
 
     /// Construct a new, empty `Range`.
     #[inline]
-    pub fn empty() -> Self {
+    pub const fn empty() -> Self {
         unsafe { Range::new(Slice::empty()) }
     }
 
@@ -792,7 +793,7 @@ impl<'a, T: 'a> Range<'a, T> {
 }
 impl<'a, T: 'a> RangeMut<'a, T> {
     #[inline]
-    unsafe fn new(s: Slice<T>) -> Self {
+    const unsafe fn new(s: Slice<T>) -> Self {
         RangeMut {
             s,
             _phantom: PhantomData,
@@ -801,7 +802,7 @@ impl<'a, T: 'a> RangeMut<'a, T> {
 
     /// Construct a new, empty `RangeMut`.
     #[inline]
-    pub fn empty() -> Self {
+    pub const fn empty() -> Self {
         unsafe { RangeMut::new(Slice::empty()) }
     }
 }
@@ -856,7 +857,7 @@ pub struct Slice<T> {
 }
 impl<T> Slice<T> {
     /// Construct a new, empty `Slice`.
-    pub fn empty() -> Self {
+    pub const fn empty() -> Self {
         Slice {
             ptr: NonNull::dangling(),
             cap: 0,
@@ -867,13 +868,13 @@ impl<T> Slice<T> {
 
     /// Returns the number of elements in the GapBuffer.
     #[inline]
-    pub fn len(&self) -> usize {
+    pub const fn len(&self) -> usize {
         self.len
     }
 
     /// Returns true if the GapBuffer contains no elements.
     #[inline]
-    pub fn is_empty(&self) -> bool {
+    pub const fn is_empty(&self) -> bool {
         self.len() == 0
     }
 
@@ -904,7 +905,7 @@ impl<T> Slice<T> {
     /// # Panics
     /// Panics if `a >= self.len()` or `b >= self.len()`.
     #[inline]
-    pub fn swap(&mut self, a: usize, b: usize) {
+    pub const fn swap(&mut self, a: usize, b: usize) {
         let oa = self.get_offset(a).expect("a is out of bounds.");
         let ob = self.get_offset(b).expect("b is out of bounds.");
         let p = self.as_mut_ptr();
@@ -1027,7 +1028,7 @@ impl<T> Slice<T> {
     pub fn as_slices(&self) -> (&[T], &[T]) {
         unsafe { self.as_slices_with_lifetime() }
     }
-    unsafe fn as_slices_with_lifetime<'a>(&self) -> (&'a [T], &'a [T]) {
+    const unsafe fn as_slices_with_lifetime<'a>(&self) -> (&'a [T], &'a [T]) {
         let p0 = self.as_ptr();
         let c1 = self.len - self.gap;
         let p1 = p0.add(self.cap - c1);
@@ -1053,7 +1054,7 @@ impl<T> Slice<T> {
     /// }
     /// assert_eq!(buf, [10, 2, 11, 4, 5]);
     /// ```
-    pub fn as_mut_slices(&mut self) -> (&mut [T], &mut [T]) {
+    pub const fn as_mut_slices(&mut self) -> (&mut [T], &mut [T]) {
         unsafe {
             let p0 = self.as_mut_ptr();
             let c1 = self.len - self.gap;
@@ -1078,7 +1079,7 @@ impl<T> Slice<T> {
     }
 
     #[inline]
-    fn get_offset(&self, index: usize) -> Option<usize> {
+    const fn get_offset(&self, index: usize) -> Option<usize> {
         if index < self.gap {
             Some(index)
         } else if index < self.len {
@@ -1089,17 +1090,17 @@ impl<T> Slice<T> {
     }
 
     #[inline]
-    fn gap_len(&self) -> usize {
+    const fn gap_len(&self) -> usize {
         self.cap - self.len
     }
 
     #[inline]
-    fn as_ptr(&self) -> *const T {
+    const fn as_ptr(&self) -> *const T {
         self.ptr.as_ptr()
     }
 
     #[inline]
-    fn as_mut_ptr(&mut self) -> *mut T {
+    const fn as_mut_ptr(&mut self) -> *mut T {
         self.ptr.as_ptr()
     }
 }

--- a/src/gap_buffer.rs
+++ b/src/gap_buffer.rs
@@ -1097,7 +1097,7 @@ impl<T> Slice<T> {
         }
 
         if end < idx {
-            panic!("slice index starts at {idx} but ends at {len}");
+            panic!("slice index starts at {idx} but ends at {end}");
         }
         (idx, end - idx)
     }

--- a/src/gap_buffer.rs
+++ b/src/gap_buffer.rs
@@ -506,6 +506,7 @@ impl<T> GapBuffer<T> {
     /// buf.drain(..);
     /// assert_eq!(buf.is_empty(), true);
     /// ```
+    #[track_caller]
     pub fn drain(&mut self, range: impl RangeBounds<usize>) -> Drain<'_, T> {
         let (idx, len) = self.to_idx_len(range);
         Drain {
@@ -537,6 +538,7 @@ impl<T> GapBuffer<T> {
     /// buf.extract_if(.., |_| true);
     /// assert_eq!(buf.is_empty(), false);
     /// ```
+    #[track_caller]
     pub fn extract_if<F>(
         &mut self,
         range: impl RangeBounds<usize>,
@@ -575,6 +577,7 @@ impl<T> GapBuffer<T> {
     /// assert_eq!(b, [1, 7, 8, 9, 4]);
     /// assert_eq!(r, [2, 3]);
     /// ```
+    #[track_caller]
     pub fn splice<I: IntoIterator<Item = T>>(
         &mut self,
         range: impl RangeBounds<usize>,
@@ -983,6 +986,7 @@ impl<T> Slice<T> {
     /// # Panics
     /// Panics if `a >= self.len()` or `b >= self.len()`.
     #[inline]
+    #[track_caller]
     pub const fn swap(&mut self, a: usize, b: usize) {
         let oa = self.get_offset(a).expect("a is out of bounds.");
         let ob = self.get_offset(b).expect("b is out of bounds.");
@@ -1007,9 +1011,12 @@ impl<T> Slice<T> {
     /// let r2 = r1.range(1..3);
     /// assert_eq!(r2, [3, 4]);
     /// ```
+    #[track_caller]
     pub fn range(&self, range: impl RangeBounds<usize>) -> Range<'_, T> {
         unsafe { self.range_with_lifetime(range) }
     }
+
+    #[track_caller]
     unsafe fn range_with_lifetime<'gb>(&self, range: impl RangeBounds<usize>) -> Range<'gb, T> {
         unsafe { Range::new(self.range_slice(range)) }
     }
@@ -1031,9 +1038,12 @@ impl<T> Slice<T> {
     /// }
     /// assert_eq!(buf, [1, 0, 3, 4, 5]);
     /// ```
+    #[track_caller]
     pub fn range_mut(&mut self, range: impl RangeBounds<usize>) -> RangeMut<'_, T> {
         unsafe { RangeMut::new(self.range_slice(range)) }
     }
+
+    #[track_caller]
     unsafe fn range_slice(&self, range: impl RangeBounds<usize>) -> Slice<T> {
         let (idx, len) = self.to_idx_len(range);
         if len == 0 {
@@ -1060,6 +1070,8 @@ impl<T> Slice<T> {
             len,
         }
     }
+
+    #[track_caller]
     fn to_idx_len(&self, range: impl RangeBounds<usize>) -> (usize, usize) {
         use std::ops::Bound::*;
         const MAX: usize = usize::MAX;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,10 @@
-//! `gapbuf` provides the type [`GapBuffer`].
+//! `gap_buf` provides the type [`GapBuffer`].
 //! `GapBuffer` has methods similar to [`Vec`](std::vec::Vec).
 //!
 //! # Examples
 //!
 //! ```
-//! use gapbuf::gap_buffer;
+//! use gap_buf::gap_buffer;
 //!
 //! let mut b = gap_buffer![1, 2, 3];
 //!
@@ -15,7 +15,7 @@
 //! assert_eq!(b, [1, 10, 3]);
 //! ```
 //!
-#![doc(html_root_url = "https://docs.rs/gapbuf/0.1.2")]
+#![doc(html_root_url = "https://docs.rs/gap_buf/0.1.2")]
 
 #[macro_use]
 mod finally;

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,4 +1,4 @@
-use gapbuf::{gap_buffer, GapBuffer};
+use gap_buf::{gap_buffer, GapBuffer};
 use std::cell::RefCell;
 use std::collections::HashSet;
 use std::panic;
@@ -700,7 +700,7 @@ fn eq_slice2() {
 }
 
 #[test]
-fn eq_gapbuf1() {
+fn eq_gap_buf1() {
     let mut buf = GapBuffer::new();
     buf.push_back(1);
 
@@ -708,7 +708,7 @@ fn eq_gapbuf1() {
 }
 
 #[test]
-fn eq_gapbuf2() {
+fn eq_gap_buf2() {
     let mut buf = GapBuffer::new();
     buf.push_back(2);
     buf.push_back(8);
@@ -838,23 +838,23 @@ fn covariant() {
     let s = String::from("bbb");
 
     // `&GapBuffer<&static str>` can convert `&GapBuffer<&a>`
-    fn c_gapbuf<'a>(_buf: &GapBuffer<&'a str>, _s: &'a str) {}
-    c_gapbuf(&b, &s);
+    fn c_gap_buf<'a>(_buf: &GapBuffer<&'a str>, _s: &'a str) {}
+    c_gap_buf(&b, &s);
 
     // `Range<'b, &'static str>` can convert  `Range<'b, &'a str>`
-    fn c_range<'a>(_buf: gapbuf::Range<&'a str>, _s: &'a str) {}
+    fn c_range<'a>(_buf: gap_buf::Range<&'a str>, _s: &'a str) {}
     c_range(b.range(0..1), &s);
 
     // `Range<'b, &'static str>` can not convert  `Range<'b, &'a str>`
-    // fn c_range_mut<'a, 'b>(_buf: gapbuf::RangeMut<'b, &'a str>, _s: &'a str) {}
+    // fn c_range_mut<'a, 'b>(_buf: gap_buf::RangeMut<'b, &'a str>, _s: &'a str) {}
     // c_range_mut(b.range_mut(0..1), &s);
 
     // `&Slice<&static str>` can convert `&Slice<&a>`
-    fn c_slice<'a>(_buf: &gapbuf::Slice<&'a str>, _s: &'a str) {}
+    fn c_slice<'a>(_buf: &gap_buf::Slice<&'a str>, _s: &'a str) {}
     c_slice(&b, &s);
 
     // `&mut Slice<&static str>` can not convert `&mut Slice<&a>`
-    // fn c_mut_slice<'a>(_buf: &mut gapbuf::Slice<&'a str>, _s: &'a str) {}
+    // fn c_mut_slice<'a>(_buf: &mut gap_buf::Slice<&'a str>, _s: &'a str) {}
     // c_mut_slice(&mut b, &s);
 }
 

--- a/tests/tests_proptest.rs
+++ b/tests/tests_proptest.rs
@@ -1,4 +1,4 @@
-use gapbuf::GapBuffer;
+use gap_buf::GapBuffer;
 use proptest::{collection::vec, prelude::*};
 use test_strategy::{proptest, Arbitrary};
 


### PR DESCRIPTION
Hello

In `std`, `Vec::new()` is a `const` function. To me, it seems unexpected that `Gapbuffer::new()` is not a `const` function. This also prevents some useful statements like

```rust
static MUTEX = Mutex<GapBuffer<u8>> = Mutex::new(GapBuffer::new());
```

Instead, because of the non `const`ness of `GapBuffer::new()`, you are forced to write:

```rust
static MUTEX: LazyLock<Mutex<GapBuffer<u8>>> = LazyLock::new(Mutex::default);
```

Which not only is more of a mouthful, in theory it is also slower, because of the `LazyLock` part.